### PR TITLE
numeric and integer validators error with factors

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -25,15 +25,18 @@ jobs:
           #- {os: macOS-latest,   r: 'devel'}
           - {os: macOS-latest,   r: 'release'}
           - {os: macOS-latest,   r: 'oldrel-1'}
+          - {os: macOS-latest,   r: 'oldrel-2'}
 
           - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: 'oldrel-1'}
+          - {os: windows-latest, r: 'oldrel-2'}
 
           # Use older ubuntu to maximise backward compatibility
           - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-18.04,   r: 'release'}
           - {os: ubuntu-18.04,   r: 'oldrel-1'}
+          - {os: ubuntu-18.04,   r: 'oldrel-2'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -25,7 +25,7 @@ jobs:
           #- {os: macOS-latest,   r: 'devel'}
           - {os: macOS-latest,   r: 'release'}
           - {os: macOS-latest,   r: 'oldrel-1'}
-          - {os: macOS-latest,   r: 'oldrel-2'}
+          #- {os: macOS-latest,   r: 'oldrel-2'}
 
           - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}

--- a/R/validation-type.R
+++ b/R/validation-type.R
@@ -65,8 +65,6 @@ isOfType <- function(object, type, nullAllowed = FALSE) {
 #' validateIsLogical(TRUE)
 #' @export
 validateIsOfType <- function(object, type, nullAllowed = FALSE) {
-  type <- c(type)
-
   # special case for integer to ensure that we call the special method
   if (length(type) == 1 && type[1] == "integer") {
     return(validateIsInteger(object, nullAllowed = nullAllowed))

--- a/tests/testthat/test-validation-inclusion.R
+++ b/tests/testthat/test-validation-inclusion.R
@@ -31,9 +31,11 @@ test_that("isIncluded returns `TRUE` when base type values are included", {
 })
 
 test_that("isIncluded returns `TRUE` when compound type values are included", {
+  skip_if_not(getRversion() > "4.1") # for factors
+
   expect_true(isIncluded(as.factor("a"), c("a", "b")))
-  expect_true(isIncluded(c("a", "b"), as.factor(c("a", "b"))))
   expect_true(isIncluded(as.factor("a"), list("a", "b")))
+  expect_true(isIncluded(c("a", "b"), as.factor(c("a", "b"))))
   expect_true(isIncluded(list("a", "b"), as.factor(c("a", "b"))))
   expect_true(isIncluded(as.Date("1970-02-01"), c(as.Date("1970-02-01"), as.Date("1980-12-21"))))
   expect_true(isIncluded(as.Date("1970-02-01"), list(as.Date("1970-02-01"), as.Date("1980-12-21"))))
@@ -52,9 +54,11 @@ test_that("isIncluded returns `FALSE` when base type values are not included", {
 })
 
 test_that("isIncluded returns `FALSE` when compound type values are not included", {
+  skip_if_not(getRversion() > "4.1") # for factors
+
   expect_false(isIncluded(as.factor("a"), c("d", "b")))
-  expect_false(isIncluded(c("a", "b"), as.factor(c("d", "b"))))
   expect_false(isIncluded(as.factor("a"), list("c", "b")))
+  expect_false(isIncluded(c("a", "b"), as.factor(c("d", "b"))))
   expect_false(isIncluded(list("a", "b"), as.factor(c("c", "b"))))
   expect_false(isIncluded(as.Date("1970-02-01"), c(as.Date("1972-02-01"), as.Date("1980-12-21"))))
   expect_false(isIncluded(as.Date("1970-02-01"), list(as.Date("1980-02-01"), as.Date("1980-12-21"))))

--- a/tests/testthat/test-validation-inclusion.R
+++ b/tests/testthat/test-validation-inclusion.R
@@ -31,8 +31,6 @@ test_that("isIncluded returns `TRUE` when base type values are included", {
 })
 
 test_that("isIncluded returns `TRUE` when compound type values are included", {
-  skip_if_not(getRversion() > "4.1")
-
   expect_true(isIncluded(as.factor("a"), c("a", "b")))
   expect_true(isIncluded(c("a", "b"), as.factor(c("a", "b"))))
   expect_true(isIncluded(as.factor("a"), list("a", "b")))
@@ -54,8 +52,6 @@ test_that("isIncluded returns `FALSE` when base type values are not included", {
 })
 
 test_that("isIncluded returns `FALSE` when compound type values are not included", {
-  skip_if_not(getRversion() > "4.1")
-
   expect_false(isIncluded(as.factor("a"), c("d", "b")))
   expect_false(isIncluded(c("a", "b"), as.factor(c("d", "b"))))
   expect_false(isIncluded(as.factor("a"), list("c", "b")))

--- a/tests/testthat/test-validation-type.R
+++ b/tests/testthat/test-validation-type.R
@@ -105,6 +105,17 @@ test_that("validateIsInteger produces expected error message when validating tha
   )
 })
 
+test_that("validateIsInteger produces errors if a factor is provided", {
+  df <- data.frame(numCol = c(1, 2, 3))
+  df$numCol <- as.factor(df$numCol)
+
+  expect_error(
+    validateIsInteger(df$numCol),
+    "argument 'df$numCol' is of type 'factor', but expected 'integer'!",
+    fixed = TRUE
+  )
+})
+
 # validateIsCharacter ------------------------------
 
 test_that("validateIsCharacter returns `NULL` for characters", {
@@ -129,6 +140,17 @@ test_that("validateIsNumeric returns `NULL` for numeric", {
 test_that("validateIsNumeric produces errors if not numeric", {
   expect_error(validateIsNumeric(c("1.2", "2.3")))
   expect_error(validateIsNumeric(list("1.2", "2.3")))
+})
+
+test_that("validateIsNumeric produces errors if a factor is provided", {
+  df <- data.frame(numCol = c(1, 2, 3))
+  df$numCol <- as.factor(df$numCol)
+
+  expect_error(
+    validateIsNumeric(df$numCol),
+    "argument 'df$numCol' is of type 'factor', but expected 'numeric, or integer'!",
+    fixed = TRUE
+  )
 })
 
 # validateIsLogical ------------------------------

--- a/tests/testthat/test-validation-type.R
+++ b/tests/testthat/test-validation-type.R
@@ -143,6 +143,8 @@ test_that("validateIsNumeric produces errors if not numeric", {
 })
 
 test_that("validateIsNumeric produces errors if a factor is provided", {
+  skip_if_not(getRversion() > "4.1") # for factors
+
   df <- data.frame(numCol = c(1, 2, 3))
   df$numCol <- as.factor(df$numCol)
 

--- a/tests/testthat/test-validation-type.R
+++ b/tests/testthat/test-validation-type.R
@@ -143,8 +143,6 @@ test_that("validateIsNumeric produces errors if not numeric", {
 })
 
 test_that("validateIsNumeric produces errors if a factor is provided", {
-  skip_if_not(getRversion() > "4.1")
-
   df <- data.frame(numCol = c(1, 2, 3))
   df$numCol <- as.factor(df$numCol)
 

--- a/tests/testthat/test-validation-type.R
+++ b/tests/testthat/test-validation-type.R
@@ -143,6 +143,8 @@ test_that("validateIsNumeric produces errors if not numeric", {
 })
 
 test_that("validateIsNumeric produces errors if a factor is provided", {
+  skip_if_not(getRversion() > "4.1")
+
   df <- data.frame(numCol = c(1, 2, 3))
   df$numCol <- as.factor(df$numCol)
 


### PR DESCRIPTION
The behaviour of `validateIsNumeric()` is different with factors for R versions `>= 4.1` and `< 4.1` due to the following [change](https://cran.r-project.org/bin/windows/base/old/4.1.0/NEWS.R-4.1.0.html):

> Using c() to combine a factor with other factors now gives a factor, an ordered factor when combining ordered factors with identical levels.

The current PR adds tests to make sure that the correct behaviour continues to be observed for `R > 4.1`, and we don't unintentionally introduce a regression.

Closes #94