### PR TITLE
Improve enum error messages with suggestions for similar keys/values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ospsuite.utils (development version)
 
+## Minor improvements and bug fixes
+
+* Improved error messages in `validateEnumValue()` and `enumGetValue()` to provide helpful suggestions when a close match is found. Both functions now use edit distance (Levenshtein distance ≤ 2) to suggest similar valid values or keys, making it easier to identify and fix typos in enum values and keys. (\#185)
+
 # ospsuite.utils 1.8.0
 
 ## Major changes

--- a/R/enum.R
+++ b/R/enum.R
@@ -101,7 +101,7 @@ getEnumKey <- enumGetKey
 
 enumGetValue <- function(enum, key) {
   if (!enumHasKey(key, enum)) {
-    stop(messages$errorKeyNotInEnum(key, deparse(substitute(enum)), enum))
+    stop(messages$errorKeyNotInEnum(key, enum, deparse(substitute(enum))))
   }
 
   return(enum[[key]])

--- a/R/enum.R
+++ b/R/enum.R
@@ -101,7 +101,7 @@ getEnumKey <- enumGetKey
 
 enumGetValue <- function(enum, key) {
   if (!enumHasKey(key, enum)) {
-    stop(messages$errorKeyNotInEnum(key))
+    stop(messages$errorKeyNotInEnum(key, deparse(substitute(enum)), enum))
   }
 
   return(enum[[key]])

--- a/R/messages.R
+++ b/R/messages.R
@@ -16,20 +16,24 @@
 #'
 #' # example display with warning
 #' warning(messages$errorPropertyReadOnly("age"))
-#' 
+#'
 #' # example display using logs
 #' logInfo(messages$errorPropertyReadOnly("age"))
 #'
 #' @export
 messages <- list(
-  errorGetEntityMultipleOutputs = function(path, container, optionalMessage = NULL) {
+  errorGetEntityMultipleOutputs = function(
+    path,
+    container,
+    optionalMessage = NULL
+  ) {
     callingFunction <- .getCallingFunctionName()
     cliFormat(
       paste(
         "{.fn {callingFunction}}: the path {.val {toString(path)}}",
         "located under container {.url {container$path}}",
         "leads to more than {.strong one entity}!"
-        ),
+      ),
       paste(
         "Use {.fn getAllXXXMatching} to get the list of all entities matching the path,",
         "where {.val XXX} stands for the entity type (e.g. {.emph Containers})"
@@ -43,7 +47,7 @@ messages <- list(
       paste(
         "{.fn {callingFunction}}: no entity exists for path {.val {toString(path)}}",
         "located under container {.url {container$path}}!"
-        ),
+      ),
       optionalMessage
     )
   },
@@ -67,23 +71,25 @@ messages <- list(
   errorSimulationBatchNothingToVary = "You need to vary at least one parameter or one molecule in order to use the SimulationBatch",
   errorMultipleMetaDataEntries = function(optionalMessage = NULL) {
     cliFormat(
-      "Can only add a strong single meta data entry at once", 
+      "Can only add a strong single meta data entry at once",
       optionalMessage
-      )
+    )
   },
   errorMultipleSimulationsCannotBeUsedWithPopulation = "Multiple simulations cannot be run concurrently with a population.",
   errorDataSetNameMissing = "Argument `name` is missing, must be provided when
   creating an empty `DataSet`!",
-  errorWrongType = function(objectName,
-                            type,
-                            expectedType,
-                            optionalMessage = NULL) {
+  errorWrongType = function(
+    objectName,
+    type,
+    expectedType,
+    optionalMessage = NULL
+  ) {
     callingFunction <- .getCallingFunctionName()
     cliFormat(
       paste(
         "{.fn {callingFunction}}: argument {.val {objectName}} is of type {.cls {type}},",
         "but expected {.cls {expectedType}}!"
-        ),
+      ),
       optionalMessage
     )
   },
@@ -102,16 +108,20 @@ messages <- list(
       paste(
         "{.fn {callingFunction}}: {.field Object} should be of length {.val {nbElements}},",
         "but is of length {.val {length(object)}} instead."
-        ),
-        optionalMessage
+      ),
+      optionalMessage
     )
   },
-  errorWrongFileExtension = function(actualExtension, expectedExtension, optionalMessage = NULL) {
+  errorWrongFileExtension = function(
+    actualExtension,
+    expectedExtension,
+    optionalMessage = NULL
+  ) {
     cliFormat(
       paste(
         "Provided file has extension {.file {actualExtension}},",
         "while {.file {expectedExtension}} was expected instead."
-        ),
+      ),
       optionalMessage
     )
   },
@@ -134,11 +144,22 @@ messages <- list(
   },
   errorCannotSetRHSFormula = "Creating a RHS Formula is not supported at the moment. This should be done in MoBi.",
   errorEnumNotAllNames = "The enumValues has some but not all names assigned.\nThey must be all assigned or none assigned",
-  errorValueNotInEnum = function(enum, value) {
-    cliFormat("Value {.val {value}} is not in defined enumeration values: {.field {names(enum)}}.")
+  errorValueNotInEnum = function(enum, enum_id, value) {
+    similarValues <- enum[adist(value, enum) <= 2]
+    cliFormat(
+      "No value with the key {.field {value}} is present in the enum!",
+      if (length(similarValues) > 0) {
+        "Did you mean one of these: {.field {similarValues}} ?"
+      } else {
+        NULL
+      },
+      "All valid values can be found using {.code {enum_id}}"
+    )
   },
   errorEnumValueUndefined = function(enum) {
-    cliFormat("Provided value is not in defined enumeration values: {.field {names(enum)}}.")
+    cliFormat(
+      "Provided value is not in defined enumeration values: {.field {names(enum)}}."
+    )
   },
   errorKeyInEnumPresent = function(key, optionalMessage = NULL) {
     cliFormat(
@@ -147,11 +168,22 @@ messages <- list(
       optionalMessage
     )
   },
-  errorKeyNotInEnum = function(key) {
-    cliFormat("No value with the key {.field {key}} is present in the enum!")
+  errorKeyNotInEnum = function(key, enum_id, enum) {
+    similarKeys <- names(enum)[adist(key, names(enum)) <= 2]
+    cliFormat(
+      "No value with the key {.field {key}} is present in the enum!",
+      if (length(similarKeys) > 0) {
+        "Did you mean one of these: {.field {similarKeys}} ?"
+      } else {
+        NULL
+      },
+      "All valid keys can be found using {.code {enum_id}}"
+    )
   },
   errorUnitNotDefined = function(quantityName, dimension, unit) {
-    cliFormat("Unit {.val {unit}} is not defined in dimension {.field {dimension}} used by {.url {quantityName}}.")
+    cliFormat(
+      "Unit {.val {unit}} is not defined in dimension {.field {dimension}} used by {.url {quantityName}}."
+    )
   },
   errorDimensionNotSupported = function(dimension, optionalMessage = NULL) {
     cliFormat(
@@ -167,14 +199,16 @@ messages <- list(
     )
   },
   errorNotIncluded = function(values, parentValues) {
-    cliFormat("{length(values)} value{?s} ({.val {values}}) {?is/are} not included in parent values: {.field {parentValues}}.")
+    cliFormat(
+      "{length(values)} value{?s} ({.val {values}}) {?is/are} not included in parent values: {.field {parentValues}}."
+    )
   },
   errorEntityPathNotAbsolute = function(path) {
     callingFunction <- .getCallingFunctionName()
     cliFormat(paste(
       "{.fn {callingFunction}}: Only absolute paths (i.e. without the wildcard(s) {.strong *}) are allowed,",
       "but the given path is: {.val {path}}"
-      ))
+    ))
   },
   errorOnlyOneValuesSetAllowed = function(argumentName) {
     callingFunction <- .getCallingFunctionName()
@@ -185,15 +219,15 @@ messages <- list(
   },
   errorOnlyOneSupported = function(optionalMessage = NULL) {
     cliFormat(
-      "Can only add a single instance of this object", 
+      "Can only add a single instance of this object",
       optionalMessage
-      )
+    )
   },
   errorDuplicatedValues = function(optionalMessage = NULL) {
     cliFormat(
-      "Object has duplicated values; only unique values are allowed.", 
+      "Object has duplicated values; only unique values are allowed.",
       optionalMessage
-      )
+    )
   },
   errorOnlyVectorAllowed = function() {
     cliFormat("Argument to parameter {.val x} can only be a vector.")
@@ -210,12 +244,14 @@ messages <- list(
   errorValueRange = function(valueRange) {
     callingFunction <- .getCallingFunctionName()
     if (any(is.na(valueRange))) {
-      cliFormat("{.fn {callingFunction}}: {.val valueRange} must not contain {.strong NA} values.")
+      cliFormat(
+        "{.fn {callingFunction}}: {.val valueRange} must not contain {.strong NA} values."
+      )
     } else {
       cliFormat(
         "{.fn {callingFunction}}: {.val valueRange} must be a vector of {.strong length 2} and in {.strong ascending order}",
         '{.field valueRange} was {.val {ifelse(is.null(valueRange), "NULL", toString(valueRange))}}.'
-        )
+      )
     }
   },
   errorValueRangeType = function(valueRange, type) {
@@ -259,7 +295,7 @@ messages <- list(
     cliFormat(
       "{length(notIncludedValues)} value{?s} ({.val {notIncludedValuesStr}}) not included in allowed values.",
       "Allowed values: {.val {parentValuesStr}}"
-      )
+    )
   },
   errorTypeNotSupported = function(objectName, type, expectedType) {
     callingFunction <- .getCallingFunctionName()
@@ -270,7 +306,9 @@ messages <- list(
   },
   errorFileNotUTF8 = function(file) {
     callingFunction <- .getCallingFunctionName()
-    cliFormat("{.fn {callingFunction}}: File {.file {file}} is {.strong not} UTF-8 encoded.")
+    cliFormat(
+      "{.fn {callingFunction}}: File {.file {file}} is {.strong not} UTF-8 encoded."
+    )
   }
 )
 

--- a/R/messages.R
+++ b/R/messages.R
@@ -147,7 +147,7 @@ messages <- list(
   errorValueNotInEnum = function(enum, enum_id, value) {
     similarValues <- enum[adist(value, enum) <= 2]
     cliFormat(
-      "No value with the key {.field {value}} is present in the enum!",
+      "{.field {value}} is not valid in {.code {enum_id}}",
       if (length(similarValues) > 0) {
         "Did you mean one of these: {.field {similarValues}} ?"
       } else {
@@ -171,7 +171,7 @@ messages <- list(
   errorKeyNotInEnum = function(key, enum_id, enum) {
     similarKeys <- names(enum)[adist(key, names(enum)) <= 2]
     cliFormat(
-      "No value with the key {.field {key}} is present in the enum!",
+      "{.field {key}} is not a valid key in {.code {enum_id}}",
       if (length(similarKeys) > 0) {
         "Did you mean one of these: {.field {similarKeys}} ?"
       } else {

--- a/R/messages.R
+++ b/R/messages.R
@@ -169,7 +169,8 @@ messages <- list(
     )
   },
   errorKeyNotInEnum = function(key, enum_id, enum) {
-    similarKeys <- names(enum)[adist(key, names(enum)) <= 2]
+    enumNames <- names(enum)
+    similarKeys <- enumNames[adist(key, enumNames) <= 2]
     cliFormat(
       "{.field {key}} is not a valid key in {.code {enum_id}}",
       if (length(similarKeys) > 0) {

--- a/R/messages.R
+++ b/R/messages.R
@@ -144,16 +144,18 @@ messages <- list(
   },
   errorCannotSetRHSFormula = "Creating a RHS Formula is not supported at the moment. This should be done in MoBi.",
   errorEnumNotAllNames = "The enumValues has some but not all names assigned.\nThey must be all assigned or none assigned",
-  errorValueNotInEnum = function(enum, enum_id, value) {
+  errorValueNotInEnum = function(enum, value, enumId) {
     similarValues <- enum[adist(value, enum) <= 2]
     cliFormat(
-      "{.field {value}} is not valid in {.code {enum_id}}",
+      if (is.null(enumId)) {
+        "{.field {value}} is not a valid value in the enum"
+      } else {
+        "{.field {value}} is not a valid value in {.code {enumId}}"
+      },
       if (length(similarValues) > 0) {
         "Did you mean one of these: {.field {similarValues}} ?"
-      } else {
-        NULL
       },
-      "All valid values can be found using {.code {enum_id}}"
+      "All valid values can be found using {.code {enumId}}"
     )
   },
   errorEnumValueUndefined = function(enum) {
@@ -168,17 +170,19 @@ messages <- list(
       optionalMessage
     )
   },
-  errorKeyNotInEnum = function(key, enum_id, enum) {
+  errorKeyNotInEnum = function(key, enum, enumId = NULL) {
     enumNames <- names(enum)
     similarKeys <- enumNames[adist(key, enumNames) <= 2]
     cliFormat(
-      "{.field {key}} is not a valid key in {.code {enum_id}}",
+      if (is.null(enumId)) {
+        "{.field {key}} is not a valid key in the enum"
+      } else {
+        "{.field {key}} is not a valid key in {.code {enumId}}"
+      },
       if (length(similarKeys) > 0) {
         "Did you mean one of these: {.field {similarKeys}} ?"
-      } else {
-        NULL
       },
-      "All valid keys can be found using {.code {enum_id}}"
+      "All valid keys can be found using {.code {enumId}}"
     )
   },
   errorUnitNotDefined = function(quantityName, dimension, unit) {

--- a/R/validation-enum.R
+++ b/R/validation-enum.R
@@ -24,5 +24,5 @@ validateEnumValue <- function(value, enum, nullAllowed = FALSE) {
     return()
   }
 
-  stop(messages$errorValueNotInEnum(enum, deparse(substitute(enum)), value))
+  stop(messages$errorValueNotInEnum(enum, value, deparse(substitute(enum))))
 }

--- a/R/validation-enum.R
+++ b/R/validation-enum.R
@@ -24,5 +24,5 @@ validateEnumValue <- function(value, enum, nullAllowed = FALSE) {
     return()
   }
 
-  stop(messages$errorValueNotInEnum(enum, value))
+  stop(messages$errorValueNotInEnum(enum, deparse(substitute(enum)), value))
 }

--- a/tests/testthat/test-validation-enum.R
+++ b/tests/testthat/test-validation-enum.R
@@ -1,5 +1,33 @@
 Symbol <- enum(c(Diamond = 1, Triangle = 2, Circle = 2))
 
+Units <- enum(c(
+  "g/l" = "g/l",
+  "mg/l" = "mg/l",
+  "ug/l" = "ug/l",
+  "ng/l" = "ng/l",
+  "pg/l" = "pg/l",
+  "g/ml" = "g/ml",
+  "mg/ml" = "mg/ml",
+  "ug/ml" = "ug/ml",
+  "ng/ml" = "ng/ml",
+  "pg/ml" = "pg/ml",
+  "mol/l" = "mol/l",
+  "mmol/l" = "mmol/l",
+  "umol/l" = "umol/l",
+  "nmol/l" = "nmol/l",
+  "pmol/l" = "pmol/l",
+  "M" = "M",
+  "mM" = "mM",
+  "uM" = "uM",
+  "nM" = "nM",
+  "pM" = "pM",
+  "mol/ml" = "mol/ml",
+  "mmol/ml" = "mmol/ml",
+  "umol/ml" = "umol/ml",
+  "nmol/ml" = "nmol/ml",
+  "pmol/ml" = "pmol/ml"
+))
+
 test_that("validateEnumValue returns `NULL` when validation is successful", {
   expect_null(validateEnumValue(NULL, nullAllowed = TRUE))
   expect_null(validateEnumValue(1, Symbol))
@@ -8,4 +36,65 @@ test_that("validateEnumValue returns `NULL` when validation is successful", {
 test_that("validateEnumValue produces error when validation is unsuccessful", {
   expect_error(validateEnumValue(4, Symbol))
   expect_error(validateEnumValue(NULL))
+})
+
+
+test_that("validateEnumValue prints suggestions for close matches and fallback hint otherwise", {
+  # Close match (edit distance 1): suggestions are shown and include the likely candidate
+  expect_error(
+    validateEnumValue("mol/L", Units),
+    regexp = "Did you mean one of these:"
+  )
+  expect_error(
+    validateEnumValue("mol/L", Units),
+    regexp = "mol/l" # Should suggest the correct lowercase version
+  )
+  expect_error(
+    validateEnumValue("mol/L", Units),
+    regexp = "All valid values can be found using" # Generic hint is always shown
+  )
+
+  # Another close match (edit distance 1): single character typo
+  expect_error(
+    validateEnumValue("ug/m", Units), # missing 'l' at the end
+    regexp = "Did you mean one of these:"
+  )
+
+  # Close match (edit distance 2): two character difference
+  expect_error(
+    validateEnumValue("mmol/ML", Units), # ML vs ml = 2 chars different
+    regexp = "Did you mean one of these:"
+  )
+  expect_error(
+    validateEnumValue("mmol/ML", Units),
+    regexp = "mmol/ml" # Should suggest the correct version
+  )
+
+  # Boundary case: edit distance exactly 2 (should still show suggestions)
+  expect_error(
+    validateEnumValue("mol/LL", Units), # LL vs l = 2 char edit distance
+    regexp = "Did you mean one of these:"
+  )
+
+  # Far match (edit distance > 2): no suggestions, only generic hint is shown
+  err_msg <- tryCatch(
+    validateEnumValue("mol/MLK", Units),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(err_msg, "All valid values can be")
+  expect_false(grepl("Did you mean one of these:", err_msg)) # Should NOT contain suggestions
+
+  # Completely unrelated value: no suggestions
+  err_msg2 <- tryCatch(
+    validateEnumValue("kilometers", Units),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(err_msg2, "All valid values can be found")
+  expect_false(grepl("Did you mean one of these:", err_msg2)) # Should NOT contain suggestions
+
+  # Multiple possible suggestions: when several values are close
+  expect_error(
+    validateEnumValue("mg/M", Units), # could suggest mg/ml or mg/l
+    regexp = "Did you mean one of these:"
+  )
 })


### PR DESCRIPTION
``` r
devtools::load_all()
#> ℹ Loading ospsuite.utils

UnitsEnum <- enum(
  c(
    "g/l" = "g/l",
    "mg/l" = "mg/l",
    "ug/l" = "ug/l",
    "ng/l" = "ng/l",
    "pg/l" = "pg/l",
    "mol/ml" = "mol/ml",
    "mmol/ml" = "mmol/ml",
    "umol/ml" = "umol/ml",
    "nmol/ml" = "nmol/ml",
    "pmol/ml" = "pmol/ml",
    "mol/l" = "mol/l"
  )
)

# Suggestions for close matches
## case difference
validateEnumValue("mol/L", UnitsEnum)
#> Error in validateEnumValue("mol/L", UnitsEnum): mol/L is not valid in `UnitsEnum`
#> Did you mean one of these: mol/ml and mol/l ?
#> All valid values can be found using `UnitsEnum`

## single character typo
validateEnumValue("ug/m", UnitsEnum)
#> Error in validateEnumValue("ug/m", UnitsEnum): ug/m is not valid in `UnitsEnum`
#> Did you mean one of these: g/l, mg/l, ug/l, ng/l, and pg/l ?
#> All valid values can be found using `UnitsEnum`

# Fallback hint when no close matches
validateEnumValue("gallon", UnitsEnum)
#> Error in validateEnumValue("gallon", UnitsEnum): gallon is not valid in `UnitsEnum`
#> 
#> All valid values can be found using `UnitsEnum`

# No error when valid
validateEnumValue("mg/l", UnitsEnum)
#> NULL
```

<sup>Created on 2025-10-03 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Similar for key checks in `enumGetValue()`