### PR TITLE
Fix errorDimensionNotSupported message function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ospsuite.utils (development version)
 
+## Minor improvements and bug fixes
+
+- Fixed `errorDimensionNotSupported` message not interpolating the dimension value (#222).
+
 # ospsuite.utils 1.11.0
 
 ## Minor improvements and bug fixes

--- a/R/messages.R
+++ b/R/messages.R
@@ -197,7 +197,7 @@ messages <- list(
   },
   errorDimensionNotSupported = function(dimension, optionalMessage = NULL) {
     cliFormat(
-      "Dimension {.val dimension} is {.strong not} supported!",
+      "Dimension {.val {dimension}} is {.strong not} supported!",
       "See enum {.code ospsuite::ospDimensions} for the list of supported dimensions.",
       optionalMessage
     )


### PR DESCRIPTION
Fixes Open-Systems-Pharmacology/OSPSuite-R#1822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error messages for unsupported dimensions now display the actual dimension value that triggered the error, providing clearer context for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->