### PR TITLE
Update personal website link to new domain

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,7 +5,7 @@ authors:
     href: "https://github.com/Open-Systems-Pharmacology"
     html: "<img src='https://www.open-systems-pharmacology.org/OSPSuite.RUtils/reference/figures/osps.png' height=24>"
   Indrajeet Patil:
-    href: https://sites.google.com/site/indrajeetspatilmorality/
+    href: https://indrajeetpatil.github.io/
 
 template:
   bootstrap: 5


### PR DESCRIPTION
The author's personal website has moved from the old Google Sites domain to a new domain.

This updates the author link in `_pkgdown.yml` accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated author information link on the documentation website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->